### PR TITLE
AspectJMergeJars: fixed no such property issue

### DIFF
--- a/AspectJ-gradle/src/main/groovy/com/archinamon/api/AspectJMergeJars.groovy
+++ b/AspectJ-gradle/src/main/groovy/com/archinamon/api/AspectJMergeJars.groovy
@@ -35,7 +35,7 @@ public class AspectJMergeJars {
             try {
                 jarMerger.setFilter(new ZipEntryFilter() {
                     @Override
-                    boolean checkEntry(String s) throws ZipAbortException {
+                    boolean checkEntry(String archivePath) throws ZipAbortException {
                         return archivePath.endsWith(SdkConstants.DOT_CLASS);
                     }
                 });


### PR DESCRIPTION
Typo in the method signature leads to 
`Caused by: groovy.lang.MissingPropertyException: No such property: archivePath for class: com.archinamon.api.AspectJMergeJars
        at com.archinamon.api.AspectJMergeJars$1.checkEntry(AspectJMergeJars.groovy:39)
        at com.android.build.gradle.internal.transforms.JarMerger.addFolder(JarMerger.java:109)
`
exception during build on the plugin versions 2.0.2. and 2.0.3 