### PR TITLE
fix *.jar file not found

### DIFF
--- a/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
+++ b/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
@@ -66,7 +66,7 @@ internal open class AspectJCompileTask : AbstractCompile() {
                 aspectJWeaver = AspectJWeaver(project)
 
                 source(sources)
-                classpath = classpath()
+                classpath = SimpleFileCollection()
                 findCompiledAspectsInClasspath(this, config.includeAspectsFromJar)
 
                 aspectJWeaver.apply {


### PR DESCRIPTION
If java/java-library plugin applied in subproject, then `classpath.files` fails to find `.jar`.
Let's postpone classpath resolving until the very end (it is done by uPhyca's fix below)